### PR TITLE
Rework CommonProperties

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,9 @@
 List changes at major/minor level. Patches should be straightforward.
 
 ## 1.1.0
-- Add coordinates formatting to display nice coordinates.
+- Remove CommonProperties from the `src/layer/layer-group.ts` file and move the `LayerUid` key into
+  `src/layer/propertiy-key.ts` as `LayerUidKey`.
+- Add coordinate formatting to display nice coordinates.
 
 ## v1.0.1
 - Start removing lodash, better import of it.

--- a/examples/layer/layer.ts
+++ b/examples/layer/layer.ts
@@ -7,7 +7,7 @@ import OlFeature from 'ol/Feature.js';
 import OlGeomPoint from 'ol/geom/Point.js';
 import { OSM } from 'ol/source.js';
 import { Map } from '../../src/map/map.js';
-import { CommonProperties } from '../../src/layer/layer-group.js';
+import { LayerUidKey } from '../../src/layer/property-key.js';
 import { BackgroundLayerGroup } from '../../src/layer/background-layer-group.js';
 import { OverlayLayerGroup } from '../../src/layer/overlay-layer-group.js';
 
@@ -51,7 +51,7 @@ backgroundLayerGroup.addLayer(backgroundLayer1, backgroundLayer1Id);
 
 // A component wanting to know changes on features for a specific layer.
 overlayLayerGroup.featuresPropertyChanged.subscribe((featurePropertyChanged) => {
-  const layer = featurePropertyChanged[CommonProperties.LayerUid];
+  const layer = featurePropertyChanged[LayerUidKey];
   const key = featurePropertyChanged.propertyKey;
   print(`Changed "${key}" in all features of layer "${layer}"`);
 });

--- a/src/interaction/draw.ts
+++ b/src/interaction/draw.ts
@@ -12,7 +12,7 @@ export const DrawInteractionGroupValue = 'olcStandardDraw';
 
 /**
  * Parent class able to enable drawing on an OpenLayers Map.
- * Manage interactions - create,  allow only one draw active at a time,
+ * Manage interactions - create, allow only one draw active at a time,
  * destroy - and let possible find back interactions to add listener on them.
  */
 export class Draw {
@@ -51,7 +51,7 @@ export class Draw {
   }
 
   /**
-   * Activate the interaction (and deactivate other draw interactions), or
+   * Activate the interaction (and deactivate other draw interactions) or
    * deactivate it.
    */
   setActive(active: boolean) {

--- a/src/layer/background-layer-group.spec.ts
+++ b/src/layer/background-layer-group.spec.ts
@@ -4,8 +4,8 @@ import OlLayerGroup from 'ol/layer/Group.js';
 import { BackgroundLayerGroup } from './background-layer-group.js';
 import { Map } from '../map/map.js';
 import { getLayerGroup } from '../test/test-data.js';
-import { CommonProperties } from './layer-group.js';
 import type OlEvent from 'ol/events/Event.js';
+import { LayerUidKey } from './property-key.js';
 
 describe('BackgroundLayerGroup', () => {
   let bgGroup: BackgroundLayerGroup;
@@ -39,7 +39,7 @@ describe('BackgroundLayerGroup', () => {
             .getLayers()
             .getArray()
             .find((layer) => layer.getVisible());
-          expect(visibleLayer?.get(CommonProperties.LayerUid)).toEqual('secondLayer');
+          expect(visibleLayer?.get(LayerUidKey)).toEqual('secondLayer');
           done('Done');
         }
       });

--- a/src/layer/background-layer-group.ts
+++ b/src/layer/background-layer-group.ts
@@ -1,5 +1,6 @@
 import OlMap from 'ol/Map.js';
-import { CommonProperties, LayerGroup, type LayerGroupOptions } from './layer-group.js';
+import { LayerGroup, type LayerGroupOptions } from './layer-group.js';
+import { LayerUidKey } from './property-key.js';
 
 export const DefaultLayerBGGroupName = 'olcBackgroundLayerGroup';
 
@@ -10,7 +11,7 @@ export const DefaultLayerBGGroupName = 'olcBackgroundLayerGroup';
  */
 export class BackgroundLayerGroup extends LayerGroup {
   constructor(map: OlMap, options: LayerGroupOptions = {}) {
-    const layerGroupUid = options[CommonProperties.LayerUid] || DefaultLayerBGGroupName;
+    const layerGroupUid = options[LayerUidKey] || DefaultLayerBGGroupName;
     super(map, layerGroupUid);
     const position = options.position ?? 0;
     this.addLayerGroup(layerGroupUid, position);
@@ -21,9 +22,7 @@ export class BackgroundLayerGroup extends LayerGroup {
    */
   toggleVisible(layerUid: string) {
     const layers = this.layerGroup.getLayers().getArray();
-    const foundLayer = layers.find(
-      (layer) => layer.get(CommonProperties.LayerUid) === layerUid,
-    );
+    const foundLayer = layers.find((layer) => layer.get(LayerUidKey) === layerUid);
     layers.forEach((layer) => {
       layer.setVisible(layer === foundLayer);
     });

--- a/src/layer/layer-group.ts
+++ b/src/layer/layer-group.ts
@@ -11,14 +11,10 @@ import type { ViewStateLayerStateExtent } from 'ol/View.js';
 import { insertAtKeepOrder } from '../collection.js';
 import { getObservable } from '../map/utils.js';
 import { isNil } from '../utils.js';
+import { LayerUidKey } from './property-key.js';
 
-/**
- * Layers common properties
- */
 export enum CommonProperties {
-  LayerUid = 'olcLayerUid',
-  Label = 'olcLabel',
-  visible = 'olcVisible',
+  LayerUidKey = 'olcLayerUid',
 }
 
 /**
@@ -31,7 +27,7 @@ export interface LayerGroupOptions {
    */
   position?: number;
   /** Unique ID for the layer group. */
-  [CommonProperties.LayerUid]?: string;
+  [LayerUidKey]?: string;
 }
 
 /**
@@ -100,7 +96,7 @@ export class LayerGroup {
       this.layerGroup
         .getLayers()
         .getArray()
-        .find((layer) => layer.get(CommonProperties.LayerUid) === layerUid) || null
+        .find((layer) => layer.get(LayerUidKey) === layerUid) || null
     );
   }
 
@@ -158,7 +154,7 @@ export class LayerGroup {
     if (this.getLayer(layerUid)) {
       return false;
     }
-    layer.set(CommonProperties.LayerUid, layerUid);
+    layer.set(LayerUidKey, layerUid);
     return true;
   }
 
@@ -175,7 +171,7 @@ export class LayerGroup {
     }
     this.layerGroup = new OlLayerGroup({
       properties: {
-        [CommonProperties.LayerUid]: layerGroupUid,
+        [LayerUidKey]: layerGroupUid,
       },
     });
     insertAtKeepOrder(
@@ -196,7 +192,7 @@ export class LayerGroup {
         .getArray()
         .find(
           (layerGroup) =>
-            layerGroup.get(CommonProperties.LayerUid) === layerUid &&
+            layerGroup.get(LayerUidKey) === layerUid &&
             layerGroup instanceof OlLayerGroup,
         ) as OlLayerGroup) || null
     );
@@ -207,7 +203,7 @@ export class LayerGroup {
    * @protected
    */
   protected getObservableName(observableName: string) {
-    const layerGroupUid = this.layerGroup.get(CommonProperties.LayerUid);
+    const layerGroupUid = this.layerGroup.get(LayerUidKey);
     return this.getObservableNameFromLayerUid(observableName, layerGroupUid);
   }
 

--- a/src/layer/overlay-layer-group.spec.ts
+++ b/src/layer/overlay-layer-group.spec.ts
@@ -8,7 +8,7 @@ import OlSourceCluster from 'ol/source/Cluster.js';
 import OlCollection from 'ol/Collection.js';
 import { OverlayLayerGroup } from './overlay-layer-group.js';
 import { Map } from '../map/map.js';
-import { CommonProperties } from './layer-group.js';
+import { LayerUidKey } from './property-key.js';
 
 describe('OverlayLayerGroup', () => {
   let overlayLayerGroup: OverlayLayerGroup;
@@ -28,8 +28,8 @@ describe('OverlayLayerGroup', () => {
         useSpatialIndex: false,
       }),
     });
-    // Add a tile layer to prove that it doesn't affect tests of method
-    // dedicated to layer with vector source and features.
+    // Add a tile layer to prove that it doesn't affect tests of the method
+    // dedicated to layer with a vector source and features.
     overlayLayerGroup.addLayer(new OlTileLayer(), tileLayerUid);
   });
 
@@ -131,7 +131,7 @@ describe('OverlayLayerGroup', () => {
     it('can does not throw error adding twice a features', () => {
       overlayLayerGroup.addFeatures(layerUid, [features[0]!]);
       expect(getOverlaySource(overlayLayer).getFeatures().length).toEqual(1);
-      // try adding already existing one
+      // try adding an already existing one
       overlayLayerGroup.addFeatures(layerUid, [features[0]!]);
       expect(getOverlaySource(overlayLayer).getFeatures().length).toEqual(1);
     });
@@ -205,7 +205,7 @@ describe('OverlayLayerGroup', () => {
       const layerUid = 'overlay';
       const features = [new OlFeature({ geometry: new OlGeomPoint([3000, -1000]) })];
       overlayLayerGroup.featuresSelected.subscribe((evt) => {
-        expect(evt[CommonProperties.LayerUid]).toBe(layerUid);
+        expect(evt[LayerUidKey]).toBe(layerUid);
         expect(evt.selected.length).toEqual(0);
         expect(evt.deselected).toBe(features);
         done('Done');
@@ -239,7 +239,7 @@ describe('OverlayLayerGroup', () => {
       const propertyKey = 'foo';
       const propertyValue = 'bar';
       overlayLayerGroup.featuresPropertyChanged.subscribe((evt) => {
-        expect(evt[CommonProperties.LayerUid]).toBe(layerUid);
+        expect(evt[LayerUidKey]).toBe(layerUid);
         expect(evt.propertyKey).toBe('foo');
         done('Done');
       });

--- a/src/layer/overlay-layer-group.ts
+++ b/src/layer/overlay-layer-group.ts
@@ -1,7 +1,8 @@
 import has from 'lodash/has.js';
 import { Subject } from 'rxjs';
 import OlMap from 'ol/Map.js';
-import { CommonProperties, LayerGroup, type LayerGroupOptions } from './layer-group.js';
+import { LayerGroup, type LayerGroupOptions } from './layer-group.js';
+import { LayerUidKey } from './property-key.js';
 import {
   createEmpty as olCreateEmptyExtent,
   extend as olExtend,
@@ -23,7 +24,7 @@ export const DefaultOverlayLayerGroupName = 'olcOverlayLayerGroup';
  * Feature selected event definition.
  */
 export interface FeatureSelected {
-  [CommonProperties.LayerUid]: string;
+  [LayerUidKey]: string;
   selected: OlFeature<OlGeometry>[];
   deselected: OlFeature<OlGeometry>[];
 }
@@ -32,7 +33,7 @@ export interface FeatureSelected {
  * Event definition for change in feature property
  */
 export interface FeaturePropertyChanged {
-  [CommonProperties.LayerUid]: string;
+  [LayerUidKey]: string;
   propertyKey: string;
 }
 
@@ -46,8 +47,7 @@ export class OverlayLayerGroup extends LayerGroup {
   private readonly featuresPropertyChangedId = 'olcOverlayLayerFeaturePropertyChanged';
 
   constructor(map: OlMap, options: LayerGroupOptions = {}) {
-    const layerGroupUid =
-      options[CommonProperties.LayerUid] || DefaultOverlayLayerGroupName;
+    const layerGroupUid = options[LayerUidKey] || DefaultOverlayLayerGroupName;
     super(map, layerGroupUid);
     const position = options.position ?? 20;
     this.addLayerGroup(layerGroupUid, position);
@@ -186,7 +186,7 @@ export class OverlayLayerGroup extends LayerGroup {
         (currentExtent, layer) =>
           olExtend(
             currentExtent,
-            this.getLayerFeaturesExtent(layer.get(CommonProperties.LayerUid)) ?? [],
+            this.getLayerFeaturesExtent(layer.get(LayerUidKey)) ?? [],
           ),
         olCreateEmptyExtent(),
       );
@@ -213,7 +213,7 @@ export class OverlayLayerGroup extends LayerGroup {
     deselected: OlFeature<OlGeometry>[],
   ) {
     this.featuresSelected.next({
-      [CommonProperties.LayerUid]: layerUid,
+      [LayerUidKey]: layerUid,
       selected,
       deselected,
     });
@@ -233,7 +233,7 @@ export class OverlayLayerGroup extends LayerGroup {
     });
     this.getLayer(layerUid)?.changed();
     this.featuresPropertyChanged.next({
-      [CommonProperties.LayerUid]: layerUid,
+      [LayerUidKey]: layerUid,
       propertyKey: key,
     });
   }

--- a/src/layer/property-key.ts
+++ b/src/layer/property-key.ts
@@ -1,0 +1,2 @@
+/** Property key in a layer to identify the layer; expected matching value: string */
+export const LayerUidKey = 'olcLayerUid';


### PR DESCRIPTION
Remove useless visibility (use ol visibility) and label (leave that to final project implementation) properties.
Move LayerUid in a better place to be imported and used more easily.