### PR TITLE
69 share same uid system

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ List changes at major/minor level. Patches should be straightforward.
 
 # 1.4.0
 - Remove lodash.
+- Use the same uid system between Interaction and LayerGroup.
+  - Drop LayerUidKey, add olcUidKey instead.
 - Add setLayerProperty method in LayerGroup
 - Remove nearly useless interaction classes.
 - Add draw box interaction and related example.

--- a/examples/layer/layer.ts
+++ b/examples/layer/layer.ts
@@ -9,7 +9,7 @@ import { OSM } from 'ol/source.js';
 import { Map } from '../../src/map/map.js';
 import { BackgroundLayerGroup } from '../../src/layer/background-layer-group.js';
 import { OverlayLayerGroup } from '../../src/layer/overlay-layer-group.js';
-import { LayerUidKey } from '../../src/layer/layer-group.js';
+import { olcUidKey } from '../../src/uid.js';
 
 // Globally accessible values you need:
 const layer1Id = 'layer1-id';
@@ -51,7 +51,7 @@ backgroundLayerGroup.addLayer(backgroundLayer1, backgroundLayer1Id);
 
 // A component wanting to know changes on features for a specific layer.
 overlayLayerGroup.featuresPropertyChanged.subscribe((featurePropertyChanged) => {
-  const layer = featurePropertyChanged[LayerUidKey];
+  const layer = featurePropertyChanged[olcUidKey];
   const key = featurePropertyChanged.propertyKey;
   print(`Changed "${key}" in all features of layer "${layer}"`);
 });

--- a/src/interaction/interactionGroup.spec.ts
+++ b/src/interaction/interactionGroup.spec.ts
@@ -1,13 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import Map from 'ol/Map.js';
 import View from 'ol/View.js';
-import {
-  DefaultGroupUid,
-  InteractionGroup,
-  InteractionGroupUidKey,
-} from './interactionGroup.js';
+import { DefaultGroupUid, InteractionGroup } from './interactionGroup.js';
 import Draw from 'ol/interaction/Draw.js';
 import VectorSource from 'ol/source/Vector.js';
+import { getOlcVirtualGroupUid } from '../uid.js';
 
 describe('Interaction', () => {
   let map: Map;
@@ -25,7 +22,7 @@ describe('Interaction', () => {
     interactionGroup.add(drawInteractionUid, drawInteraction);
     const group = interactionGroup.getGroupInteractions();
     expect(group.length).toEqual(1);
-    expect(group[0]!.get(InteractionGroupUidKey)).toBe(DefaultGroupUid);
+    expect(getOlcVirtualGroupUid(group[0]!)).toBe(DefaultGroupUid);
     // With a second group:
     const group2Uid = 'group2';
     const interactionGroup2 = new InteractionGroup(map, group2Uid);
@@ -34,7 +31,7 @@ describe('Interaction', () => {
     const group2 = interactionGroup2.getGroupInteractions();
     expect(group.length).toEqual(1); // still 1
     expect(group2.length).toEqual(1);
-    expect(group2[0]!.get(InteractionGroupUidKey)).toBe(group2Uid);
+    expect(getOlcVirtualGroupUid(group2[0]!)).toBe(group2Uid);
   });
 
   it('should add an interaction to the map', () => {

--- a/src/layer/background-layer-group.spec.ts
+++ b/src/layer/background-layer-group.spec.ts
@@ -5,7 +5,7 @@ import { BackgroundLayerGroup } from './background-layer-group.js';
 import { Map } from '../map/map.js';
 import { getLayerGroup } from '../test/test-data.js';
 import type OlEvent from 'ol/events/Event.js';
-import { LayerUidKey } from './layer-group.js';
+import { getOlcUid } from '../uid.js';
 
 describe('BackgroundLayerGroup', () => {
   let bgGroup: BackgroundLayerGroup;
@@ -51,7 +51,8 @@ describe('BackgroundLayerGroup', () => {
             .getLayers()
             .getArray()
             .find((layer) => layer.getVisible());
-          expect(visibleLayer?.get(LayerUidKey)).toEqual('secondLayer');
+          expect(visibleLayer).toBeDefined();
+          expect(getOlcUid(visibleLayer!)).toEqual('secondLayer');
           done('Done');
         }
       });

--- a/src/layer/background-layer-group.ts
+++ b/src/layer/background-layer-group.ts
@@ -1,6 +1,7 @@
 import OlMap from 'ol/Map.js';
 import OlLayerBase from 'ol/layer/Base.js';
-import { LayerGroup, type LayerGroupOptions, LayerUidKey } from './layer-group.js';
+import { LayerGroup, type LayerGroupOptions } from './layer-group.js';
+import { getOlcUid, olcUidKey } from '../uid.js';
 
 export const DefaultLayerBGGroupUid = 'olcBackgroundLayerGroupUid';
 
@@ -11,7 +12,7 @@ export const DefaultLayerBGGroupUid = 'olcBackgroundLayerGroupUid';
  */
 export class BackgroundLayerGroup extends LayerGroup {
   constructor(map: OlMap, options: LayerGroupOptions = {}) {
-    const layerGroupUid = options[LayerUidKey] ?? DefaultLayerBGGroupUid;
+    const layerGroupUid = options[olcUidKey] ?? DefaultLayerBGGroupUid;
     super(map);
     const position = options.position ?? 0;
     this.addLayerGroup(layerGroupUid, position);
@@ -34,7 +35,7 @@ export class BackgroundLayerGroup extends LayerGroup {
    */
   toggleVisible(layerUid: string) {
     const layers = this.layerGroup.getLayers().getArray();
-    const foundLayer = layers.find((layer) => layer.get(LayerUidKey) === layerUid);
+    const foundLayer = layers.find((layer) => getOlcUid(layer) === layerUid);
     layers.forEach((layer) => {
       layer.setVisible(layer === foundLayer);
     });

--- a/src/layer/layer-group.spec.ts
+++ b/src/layer/layer-group.spec.ts
@@ -4,10 +4,11 @@ import BaseLayer from 'ol/layer/Base.js';
 import OlLayerLayer from 'ol/layer/Layer.js';
 import OlSourceSource from 'ol/source/Source.js';
 import { Map } from '../map/map.js';
-import { LayerGroup, LayerUidKey } from './layer-group.js';
+import { LayerGroup } from './layer-group.js';
 import { getLayerGroup } from '../test/test-data.js';
 import { BackgroundLayerGroup } from './background-layer-group.js';
 import { CollectionEvent } from 'ol/Collection.js';
+import { olcUidKey } from '../uid.js';
 
 describe('LayersStore', () => {
   let layerGroup: LayerGroup;
@@ -68,7 +69,7 @@ describe('LayersStore', () => {
       const layerUid = 'my-layer';
       const propKey = 'test';
       layerGroup.layerPropertyChanged.subscribe((evt) => {
-        expect(evt[LayerUidKey]).toBe(layerUid);
+        expect(evt[olcUidKey]).toBe(layerUid);
         expect(evt.propertyKey).toEqual(propKey);
         expect(layerGroup.getLayer(layerUid)?.get(propKey)).toEqual('success');
         done('Done');
@@ -85,7 +86,7 @@ describe('LayersStore', () => {
       const layerUid = 'my-layer';
       const reason = 'targeted';
       layerGroup.layerAffected.subscribe((evt) => {
-        expect(evt[LayerUidKey]).toBe(layerUid);
+        expect(evt[olcUidKey]).toBe(layerUid);
         expect(evt.reason).toBe(reason);
         done('Done');
       });

--- a/src/layer/layer-group.ts
+++ b/src/layer/layer-group.ts
@@ -8,15 +8,13 @@ import type { ViewStateLayerStateExtent } from 'ol/View.js';
 import { insertAtKeepOrder } from '../collection.js';
 import { isNil, uniq } from '../utils.js';
 import { Subject } from 'rxjs';
-
-/** Property key in a layer to identify the layer; expected matching value: string */
-export const LayerUidKey = 'olcLayerUid';
+import { getOlcUid, olcUidKey } from '../uid.js';
 
 /**
  * Event definition for "affected" event of a layer in the layerGroup.
  */
 export interface LayerAffected {
-  [LayerUidKey]: string;
+  [olcUidKey]: string;
   reason: string;
 }
 
@@ -24,7 +22,7 @@ export interface LayerAffected {
  * Event definition for property change in a layer of this layerGroup.
  */
 export interface LayerPropertyChanged {
-  [LayerUidKey]: string;
+  [olcUidKey]: string;
   propertyKey: string;
 }
 
@@ -38,7 +36,7 @@ export interface LayerGroupOptions {
    */
   position?: number;
   /** Unique ID for the layer group. */
-  [LayerUidKey]?: string;
+  [olcUidKey]?: string;
 }
 
 /**
@@ -108,7 +106,7 @@ export class LayerGroup {
       this.layerGroup
         .getLayers()
         .getArray()
-        .find((layer) => layer.get(LayerUidKey) === layerUid) || null
+        .find((layer) => getOlcUid(layer) === layerUid) || null
     );
   }
 
@@ -162,7 +160,7 @@ export class LayerGroup {
    */
   emitLayerAffected(layerUid: string, reason: string) {
     this.layerAffected.next({
-      [LayerUidKey]: layerUid,
+      [olcUidKey]: layerUid,
       reason,
     });
   }
@@ -173,7 +171,7 @@ export class LayerGroup {
   emitLayerPropertyChanged(layerUid: string, propertyKey: string) {
     this.getLayer(layerUid)?.changed();
     this.layerPropertyChanged.next({
-      [LayerUidKey]: layerUid,
+      [olcUidKey]: layerUid,
       propertyKey,
     });
   }
@@ -196,7 +194,7 @@ export class LayerGroup {
     if (this.getLayer(layerUid)) {
       return false;
     }
-    layer.set(LayerUidKey, layerUid);
+    layer.set(olcUidKey, layerUid);
     return true;
   }
 
@@ -213,7 +211,7 @@ export class LayerGroup {
     }
     this.layerGroup = new OlLayerGroup({
       properties: {
-        [LayerUidKey]: layerGroupUid,
+        [olcUidKey]: layerGroupUid,
       },
     });
     insertAtKeepOrder(
@@ -234,8 +232,7 @@ export class LayerGroup {
         .getArray()
         .find(
           (layerGroup) =>
-            layerGroup.get(LayerUidKey) === layerUid &&
-            layerGroup instanceof OlLayerGroup,
+            layerGroup.get(olcUidKey) === layerUid && layerGroup instanceof OlLayerGroup,
         ) as OlLayerGroup) || null
     );
   }

--- a/src/layer/overlay-layer-group.spec.ts
+++ b/src/layer/overlay-layer-group.spec.ts
@@ -8,7 +8,7 @@ import OlSourceCluster from 'ol/source/Cluster.js';
 import OlCollection from 'ol/Collection.js';
 import { OverlayLayerGroup } from './overlay-layer-group.js';
 import { Map } from '../map/map.js';
-import { LayerUidKey } from './layer-group.js';
+import { olcUidKey } from '../uid.js';
 
 describe('OverlayLayerGroup', () => {
   let overlayLayerGroup: OverlayLayerGroup;
@@ -205,7 +205,7 @@ describe('OverlayLayerGroup', () => {
       const layerUid = 'overlay';
       const features = [new OlFeature({ geometry: new OlGeomPoint([3000, -1000]) })];
       overlayLayerGroup.featuresAffected.subscribe((evt) => {
-        expect(evt[LayerUidKey]).toBe(layerUid);
+        expect(evt[olcUidKey]).toBe(layerUid);
         expect(evt.affected.length).toEqual(0);
         expect(evt.noMoreAffected).toBe(features);
         done('Done');
@@ -239,7 +239,7 @@ describe('OverlayLayerGroup', () => {
       const propertyKey = 'foo';
       const propertyValue = 'bar';
       overlayLayerGroup.featuresPropertyChanged.subscribe((evt) => {
-        expect(evt[LayerUidKey]).toBe(layerUid);
+        expect(evt[olcUidKey]).toBe(layerUid);
         expect(evt.propertyKey).toBe('foo');
         expect(evt.features).toEqual(features);
         done('Done');

--- a/src/layer/overlay-layer-group.ts
+++ b/src/layer/overlay-layer-group.ts
@@ -1,6 +1,7 @@
 import { Subject } from 'rxjs';
 import OlMap from 'ol/Map.js';
-import { LayerGroup, type LayerGroupOptions, LayerUidKey } from './layer-group.js';
+import { getOlcUid, olcUidKey } from '../uid.js';
+import { LayerGroup, type LayerGroupOptions } from './layer-group.js';
 import {
   createEmpty as olCreateEmptyExtent,
   extend as olExtend,
@@ -21,7 +22,7 @@ export const DefaultOverlayLayerGroupUid = 'olcOverlayLayerGroupUid';
  * Event definition for "affected" event of a feature in the layerGroup.
  */
 export interface FeatureAffected {
-  [LayerUidKey]: string;
+  [olcUidKey]: string;
   reason: string;
   affected: OlFeature[];
   noMoreAffected?: OlFeature[];
@@ -31,7 +32,7 @@ export interface FeatureAffected {
  * Event definition for property change in a feature of a layer in the layerGroup.
  */
 export interface FeaturePropertyChanged {
-  [LayerUidKey]: string;
+  [olcUidKey]: string;
   propertyKey: string;
   features: OlFeature[];
 }
@@ -57,7 +58,7 @@ export class OverlayLayerGroup extends LayerGroup {
   readonly featuresPropertyChanged: Subject<FeaturePropertyChanged>;
 
   constructor(map: OlMap, options: LayerGroupOptions = {}) {
-    const layerGroupUid = options[LayerUidKey] ?? DefaultOverlayLayerGroupUid;
+    const layerGroupUid = options[olcUidKey] ?? DefaultOverlayLayerGroupUid;
     super(map);
     const position = options.position ?? 20;
     this.addLayerGroup(layerGroupUid, position);
@@ -174,7 +175,7 @@ export class OverlayLayerGroup extends LayerGroup {
         (currentExtent, layer) =>
           olExtend(
             currentExtent,
-            this.getLayerFeaturesExtent(layer.get(LayerUidKey)) ?? [],
+            this.getLayerFeaturesExtent(getOlcUid(layer) ?? '') ?? [],
           ),
         olCreateEmptyExtent(),
       );
@@ -202,7 +203,7 @@ export class OverlayLayerGroup extends LayerGroup {
     noMoreAffected?: OlFeature<OlGeometry>[],
   ) {
     this.featuresAffected.next({
-      [LayerUidKey]: layerUid,
+      [olcUidKey]: layerUid,
       reason,
       affected,
       noMoreAffected,
@@ -237,7 +238,7 @@ export class OverlayLayerGroup extends LayerGroup {
   ) {
     this.getLayer(layerUid)?.changed();
     this.featuresPropertyChanged.next({
-      [LayerUidKey]: layerUid,
+      [olcUidKey]: layerUid,
       propertyKey,
       features,
     });

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -1,7 +1,6 @@
 import OlMap from 'ol/Map.js';
 import OlControl from 'ol/control/Control.js';
-
-export const ControlUidKey = 'olcControlUid';
+import { getOlcUid, olcUidKey } from '../uid.js';
 
 /**
  * Provides helper for OL map.
@@ -24,7 +23,7 @@ export class Map {
     return this.map
       .getControls()
       .getArray()
-      .some((control) => control.get(ControlUidKey) === controlUid);
+      .some((control) => getOlcUid(control) === controlUid);
   }
 
   /**
@@ -37,7 +36,7 @@ export class Map {
     if (this.hasControl(controlUid)) {
       return;
     }
-    control.set(ControlUidKey, controlUid);
+    control.set(olcUidKey, controlUid);
     this.map.addControl(control);
   }
 

--- a/src/overlay/overlay.ts
+++ b/src/overlay/overlay.ts
@@ -1,7 +1,6 @@
 import OlMap from 'ol/Map.js';
 import OlOverlay from 'ol/Overlay.js';
-
-export const OverlayGroupUid = 'olcOverlayGroupUid';
+import { getOlcVirtualGroupUid, olcVirtualGroupUidKey } from '../uid.js';
 
 /**
  * Store and manage overlays (popups) on the map.
@@ -13,7 +12,7 @@ export class Overlay {
    * Add an overlay (with a group id) to the map.
    */
   addOverlay(overlayGroupUid: string, overlay: OlOverlay) {
-    overlay.set(OverlayGroupUid, overlayGroupUid);
+    overlay.set(olcVirtualGroupUidKey, overlayGroupUid);
     this.map.addOverlay(overlay);
   }
 
@@ -24,7 +23,7 @@ export class Overlay {
     return this.map
       .getOverlays()
       .getArray()
-      .filter((overlay) => overlay.get(OverlayGroupUid) === overlayGroupUid);
+      .filter((overlay) => getOlcVirtualGroupUid(overlay) === overlayGroupUid);
   }
 
   /**
@@ -34,7 +33,7 @@ export class Overlay {
     this.map
       .getOverlays()
       .getArray()
-      .filter((overlay: OlOverlay) => overlay.get(OverlayGroupUid) === overlayGroupUid)
+      .filter((overlay: OlOverlay) => getOlcVirtualGroupUid(overlay) === overlayGroupUid)
       .forEach((overlay: OlOverlay) => this.map.removeOverlay(overlay));
   }
 

--- a/src/uid.ts
+++ b/src/uid.ts
@@ -1,0 +1,22 @@
+import BaseObject from 'ol/Object.js';
+
+export const olcUidKey = '__olcUid__';
+export const olcVirtualGroupUidKey = '__olcVirtualGroupUid__';
+
+/**
+ * Get the ol-comfy uid of the given object.
+ * An uid is a unique identifier of an object but only unique within the same collection.
+ * @returns The ol-comfy uid of the given object.
+ */
+export const getOlcUid = (baseObject: BaseObject): string | undefined => {
+  return baseObject.get(olcUidKey) as string | undefined;
+};
+
+/**
+ * Get the ol-comfy virtual group uid of the given object.
+ * It's called a virtual group because it's not a real collection, it's object sharing the same group uid.
+ * @returns The ol-comfy virtual group uid of the given object.
+ */
+export const getOlcVirtualGroupUid = (baseObject: BaseObject): string | undefined => {
+  return baseObject.get(olcVirtualGroupUidKey) as string | undefined;
+};


### PR DESCRIPTION
For #69 

Have two olc ids to identify olc object and not more.
Be able to get the uid without needed the key value (add getOlcUid method)