### PR TITLE
Unify find in array methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ using ol-comfy.
 
 - [Documentation](https://geoblocks.github.io/ol-comfy/apidoc/index.html);
 - [Examples](https://geoblocks.github.io/ol-comfy/examples/index.html);
-- [Wiki](https://github.com/geoblocks/ol-comfy/wiki).
-- [Source code](https://github.com/geoblocks/ol-comfy)
-- [Changelog](https://github.com/geoblocks/ol-comfy/blob/main/CHANGELOG.md)
+- [Wiki](https://github.com/geoblocks/ol-comfy/wiki);
+- [Source code](https://github.com/geoblocks/ol-comfy);
+- [Changelog](https://github.com/geoblocks/ol-comfy/blob/main/CHANGELOG.md);
 
 ## Local development
 

--- a/examples/draw/index.ts
+++ b/examples/draw/index.ts
@@ -81,7 +81,7 @@ const eventKeys: EventsKey[] = [];
  */
 const setupDrawing = () => {
   // Set up the layer to draw in.
-  const drawLayer = mapEntry.getOlcOverlayLayer().getLayer(layer1Id) as
+  const drawLayer = mapEntry.getOlcOverlayLayer().findLayer(layer1Id) as
     | OlLayerVector<OlSourceVector<OlFeature>>
     | undefined;
   const source = drawLayer?.getSource();

--- a/examples/simple/index.ts
+++ b/examples/simple/index.ts
@@ -52,8 +52,8 @@ overlayLayerGroup.addLayer(overlayLayer, overlayLayerId);
 // Then, no matter where you are in your code, you can access the map with:
 olcMap.getMap();
 // The layer, or layer group functionalities with:
-backgroundLayerGroup.getLayer(backgroundLayerId);
+backgroundLayerGroup.findLayer(backgroundLayerId);
 // Or
-overlayLayerGroup.getLayer(overlayLayerId);
+overlayLayerGroup.findLayer(overlayLayerId);
 // And you can be sure that you can find you layer back, and that
 // the background layer is not above the overlay layers.

--- a/src/base.spec.ts
+++ b/src/base.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import OlBaseObject from 'ol/Object.js';
+import {
+  getSortedOlObjectsByProperty,
+  findObject,
+  filterObjects,
+  filterObjectsStartsWith,
+} from './base.js';
+
+describe('base', () => {
+  let objects: OlBaseObject[];
+
+  beforeEach(() => {
+    objects = [
+      new OlBaseObject({ prop1: 'albi', prop2: 3 }),
+      new OlBaseObject({ prop1: 'ca_co', prop2: -1 }),
+      new OlBaseObject({ prop1: 'ca_co', prop2: 4 }),
+      new OlBaseObject({ prop1: 'cz_ci', prop2: 5 }),
+      new OlBaseObject({ prop1: 'dori', prop2: 10 }),
+      new OlBaseObject({ prop1: '0', prop2: NaN }),
+    ];
+  });
+
+  it('getSortedOlObjectsByProperty', () => {
+    let sorted = getSortedOlObjectsByProperty(objects, 'prop1');
+    expect(sorted.map((obj) => obj.get('prop1'))).toEqual([
+      '0',
+      'albi',
+      'ca_co',
+      'ca_co',
+      'cz_ci',
+      'dori',
+    ]);
+    sorted = getSortedOlObjectsByProperty(objects, 'prop2');
+    expect(sorted.map((obj) => obj.get('prop2'))).toEqual([NaN, -1, 3, 4, 5, 10]);
+  });
+
+  it('findObject', () => {
+    expect(findObject(objects, 'prop1', 'ca_co')).toBe(objects[1]);
+    expect(findObject(objects, 'prop2', 4)).toBe(objects[2]);
+    expect(findObject(objects, 'prop2', 10)).toBe(objects[4]);
+    expect(findObject(objects, 'prop1', 'x')).toBeNull();
+  });
+
+  it('filterObjects', () => {
+    expect(filterObjects(objects, 'prop1', 'ca_co').length).toEqual(2);
+    expect(filterObjects(objects, 'prop2', 4)).toEqual([objects[2]]);
+    expect(filterObjects(objects, 'prop2', 10)).toEqual([objects[4]]);
+    expect(filterObjects(objects, 'prop1', 'x')).toEqual([]);
+  });
+
+  it('filterObjectsStartsWith', () => {
+    expect(filterObjectsStartsWith(objects, 'prop1', 'ca').length).toEqual(2);
+    expect(filterObjectsStartsWith(objects, 'prop1', 'c').length).toEqual(3);
+    expect(filterObjectsStartsWith(objects, 'prop1', 'cz')).toEqual([objects[3]]);
+    expect(filterObjectsStartsWith(objects, 'prop1', 'x')).toEqual([]);
+  });
+});

--- a/src/base.ts
+++ b/src/base.ts
@@ -16,3 +16,36 @@ export const getSortedOlObjectsByProperty = <T extends OlBaseObject>(
     return prop1 > prop2 ? 1 : -1;
   });
 };
+
+/**
+ * Find an object with a specific key and value.
+ */
+export const findObject = <T extends OlBaseObject>(
+  objects: T[],
+  key: string,
+  value: unknown,
+): T | null => {
+  return objects.find((obj) => obj.get(key) === value) ?? null;
+};
+
+/**
+ * Filter objects by a specific key and value.
+ */
+export const filterObjects = <T extends OlBaseObject>(
+  objects: T[],
+  key: string,
+  value: unknown,
+): T[] => {
+  return objects.filter((obj) => obj.get(key) === value);
+};
+
+/**
+ * Filter objects by a specific key and value, where the value starts with the given string.
+ */
+export const filterObjectsStartsWith = <T extends OlBaseObject>(
+  objects: T[],
+  key: string,
+  value: unknown,
+): T[] => {
+  return objects.filter((obj) => obj.get(key)?.startsWith(value));
+};

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -2,7 +2,7 @@ import OlCollection from 'ol/Collection.js';
 import OlBaseObject from 'ol/Object.js';
 
 /**
- * Get an OpenLayers object and return it sorted by the given key property.
+ * Insert an object at a specific position, keeping the order.
  */
 export const insertAtKeepOrder = <T extends OlBaseObject>(
   objects: OlCollection<T>,

--- a/src/interaction/interaction-group.spec.ts
+++ b/src/interaction/interaction-group.spec.ts
@@ -54,7 +54,7 @@ describe('Interaction', () => {
     expect(found).toBe(drawInteraction);
   });
 
-  it('should find interactions including a uidPart', () => {
+  it('should find interactions starting by uidPart', () => {
     const drawInteraction2 = new Draw({ source: new VectorSource(), type: 'Point' });
     const drawInteraction3 = new Draw({ source: new VectorSource(), type: 'Point' });
     const drawInteraction4 = new Draw({ source: new VectorSource(), type: 'Point' });
@@ -62,16 +62,16 @@ describe('Interaction', () => {
     interactionGroup.add('d-raw', drawInteraction2);
     interactionGroup.add('draw-2-b', drawInteraction3);
     interactionGroup.add('test_draw', drawInteraction4);
-    const found = interactionGroup.findByIncluding('draw');
-    // Every item matches except one.
-    expect(found.length).toBe(3);
+    const found = interactionGroup.filterStartsWith('draw');
+    // Only one item matches.
+    expect(found.length).toBe(1);
   });
 
   it('should remove an interaction by uid', () => {
     interactionGroup.add(drawInteractionUid, drawInteraction);
     interactionGroup.remove(drawInteractionUid);
     const found = interactionGroup.find(drawInteractionUid);
-    expect(found).toBeUndefined();
+    expect(found).toBeNull();
   });
 
   it('should check if an interaction exists', () => {

--- a/src/interaction/interaction-group.ts
+++ b/src/interaction/interaction-group.ts
@@ -6,6 +6,7 @@ import {
   olcUidKey,
   olcVirtualGroupUidKey,
 } from '../uid.js';
+import { filterObjects, filterObjectsStartsWith, findObject } from '../base.js';
 
 export const DefaultGroupUid = 'olcInteractionGroup';
 
@@ -26,16 +27,15 @@ export class InteractionGroup {
    * @returns all the interaction of the wanted group.
    */
   getGroupInteractions(): OlInteraction[] {
-    return this.map
-      .getInteractions()
-      .getArray()
-      .filter(
-        (interaction) => getOlcVirtualGroupUid(interaction) === this.virtualGroupUid,
-      );
+    return filterObjects(
+      this.map.getInteractions().getArray(),
+      olcVirtualGroupUidKey,
+      this.virtualGroupUid,
+    );
   }
 
   /**
-   * Adds the given interaction to the given map with an uid.
+   * Adds the given interaction (with an uid) to the map.
    * The interaction can't be in multiple groups at the same time.
    * @param uid - The uid to associate with the interaction
    * @param interaction - The interaction to add
@@ -60,25 +60,21 @@ export class InteractionGroup {
   }
 
   /**
-   * Finds an interaction by its uid
+   * Finds an interaction of this group by its uid.
    * @param uid - The uid of the interaction to find
-   * @returns The interaction if found, undefined otherwise
+   * @returns The interaction if found, null otherwise
    */
-  find(uid: string): OlInteraction | undefined {
-    return this.getGroupInteractions().find((interaction) => {
-      return getOlcUid(interaction) === uid;
-    });
+  find(uid: string): OlInteraction | null {
+    return findObject(this.getGroupInteractions(), olcUidKey, uid);
   }
 
   /**
-   * Finds all interaction having uid included in the provided uid.
-   * @param uidPart - A start part uid of the interaction to find.
-   * @returns The interaction if found or undefined otherwise.
+   * Finds all interaction of this group having their uid starting by the provided prefix.
+   * @param uidPrefix - A start part uid of the interaction to find.
+   * @returns The interactions if found or an empty array otherwise.
    */
-  findByIncluding(uidPart: string): OlInteraction[] {
-    return this.getGroupInteractions().filter((interaction) => {
-      return `${getOlcUid(interaction)}`.includes(uidPart);
-    });
+  filterStartsWith(uidPrefix: string): OlInteraction[] {
+    return filterObjectsStartsWith(this.getGroupInteractions(), olcUidKey, uidPrefix);
   }
 
   /**

--- a/src/layer/layer-group.spec.ts
+++ b/src/layer/layer-group.spec.ts
@@ -39,6 +39,25 @@ describe('LayersStore', () => {
       expect(getLayerGroup(layerGroup, 0).getLayers().getLength()).toEqual(1);
     }));
 
+  it('should findLayer', () => {
+    layerGroup.addLayer(baseLayer, 'my_layer');
+    layerGroup.addLayer(new OlLayerBase({}), 'my_2nd_Layer');
+    const found = layerGroup.findLayer('my_layer');
+    expect(found).toBe(baseLayer);
+    const notFound = layerGroup.findLayer('nonExistentLayer');
+    expect(notFound).toBeNull();
+  });
+
+  it('should findLayersStartsWith', () => {
+    layerGroup.addLayer(baseLayer, 'my_layer');
+    layerGroup.addLayer(new OlLayerBase({}), 'my_2nd_Layer');
+    layerGroup.addLayer(new OlLayerBase({}), '3th_of_my_layer');
+    const found = layerGroup.findLayersStartsWith('my');
+    expect(found.length).toBe(2);
+    const notFound = layerGroup.findLayersStartsWith('nonExistentLayer');
+    expect(notFound.length).toBe(0);
+  });
+
   it('should clearAll', () => {
     layerGroup.addLayer(baseLayer, 'myLayer');
     expect(getLayerGroup(layerGroup, 0).getLayers().getLength()).toEqual(1);
@@ -136,7 +155,7 @@ describe('LayersStore', () => {
         layerGroup.on(LayerPropertyChangedEventType, (evt: LayerPropertyChangedEvent) => {
           expect(evt[olcUidKey]).toBe(layerUid);
           expect(evt.propertyKey).toEqual(propKey);
-          expect(layerGroup.getLayer(layerUid)?.get(propKey)).toEqual('success');
+          expect(layerGroup.findLayer(layerUid)?.get(propKey)).toEqual('success');
           done('Done');
         });
         baseLayer.set(propKey, 'init');

--- a/src/layer/layer-group.ts
+++ b/src/layer/layer-group.ts
@@ -5,9 +5,10 @@ import OlLayerBase from 'ol/layer/Base.js';
 import OlLayerLayer from 'ol/layer/Layer.js';
 import OlSourceSource from 'ol/source/Source.js';
 import type { ViewStateLayerStateExtent } from 'ol/View.js';
+import { filterObjectsStartsWith, findObject } from '../base.js';
 import { insertAtKeepOrder } from '../collection.js';
 import { isNil, uniq } from '../utils.js';
-import { getOlcUid, olcUidKey } from '../uid.js';
+import { olcUidKey } from '../uid.js';
 import BaseObject, { ObjectEvent } from 'ol/Object.js';
 import type { EventsKey } from 'ol/events.js';
 import BaseEvent from 'ol/events/Event.js';
@@ -132,12 +133,19 @@ export class LayerGroup extends BaseObject {
    * Retrieve a layer currently in the layer group.
    * @returns The matching layer or null.
    */
-  getLayer(layerUid: string): OlLayerBase | null {
-    return (
-      this.layerGroup
-        .getLayers()
-        .getArray()
-        .find((layer) => getOlcUid(layer) === layerUid) || null
+  findLayer(layerUid: string): OlLayerBase | null {
+    return findObject(this.layerGroup.getLayers().getArray(), olcUidKey, layerUid);
+  }
+
+  /**
+   * Retrieve all layers currently in the layer group that start with a specific UID.
+   * @returns An array of matching layers.
+   */
+  findLayersStartsWith(layerUidPrefix: string): OlLayerBase[] {
+    return filterObjectsStartsWith(
+      this.layerGroup.getLayers().getArray(),
+      olcUidKey,
+      layerUidPrefix,
     );
   }
 
@@ -178,7 +186,7 @@ export class LayerGroup extends BaseObject {
    * Set a property of a layer and fires a "LayerPropertyChanged" event if the value has changed.
    */
   setLayerProperty(layerUid: string, propertyKey: string, value: unknown) {
-    const layer = this.getLayer(layerUid);
+    const layer = this.findLayer(layerUid);
     if (!layer || layer?.get(propertyKey) === value) {
       return;
     }
@@ -198,7 +206,7 @@ export class LayerGroup extends BaseObject {
    */
   dispatchLayerPropertyChanged(layerUid: string, propertyKey: string) {
     this.dispatchEvent(new LayerPropertyChangedEvent(layerUid, propertyKey));
-    this.getLayer(layerUid)?.changed();
+    this.findLayer(layerUid)?.changed();
   }
 
   /**
@@ -216,7 +224,7 @@ export class LayerGroup extends BaseObject {
       console.error(error);
       return false;
     }
-    if (this.getLayer(layerUid)) {
+    if (this.findLayer(layerUid)) {
       return false;
     }
     layer.set(olcUidKey, layerUid);

--- a/src/layer/overlay-layer-group.ts
+++ b/src/layer/overlay-layer-group.ts
@@ -113,7 +113,7 @@ export class OverlayLayerGroup extends LayerGroup {
    * @param layerUid the id of the layer to add features into.
    */
   getVectorLayer(layerUid: string): OlLayerVector<OlSourceVector> | null {
-    const layer = super.getLayer(layerUid);
+    const layer = super.findLayer(layerUid);
     return layer instanceof OlLayerVector ? layer : null;
   }
 
@@ -275,7 +275,7 @@ export class OverlayLayerGroup extends LayerGroup {
     features: OlFeature[],
     propertyKey: string,
   ) {
-    this.getLayer(layerUid)?.changed();
+    this.findLayer(layerUid)?.changed();
     this.dispatchEvent(new FeaturePropertyChangedEvent(layerUid, propertyKey, features));
   }
 


### PR DESCRIPTION
Fix #128 

Add common method to findObject, filterObjects, filterObjectsStartsWith And use them in an unified way in interaction-group and layer-group.

This is a breaking change:
 - `getLayer` is now called `findLayer`.
 - interaction's `findByIncluding` is now called `filterStartsWith` (and search for a prefix, not a too wide "includes").